### PR TITLE
Pull latest version automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM debian:stretch
-ENV VERSION 2.2.11
+ARG VERSION=latest
 MAINTAINER Tristan Teufel <info@teufel-it.de>
 
 RUN apt-get update
-RUN apt-get install sqlite3 libcrypto++6 libcurl3 libfuse2 -y
+RUN apt-get install sqlite3 libcrypto++6 libcurl3 libfuse2 wget -y
 
-ADD https://www.urbackup.org/downloads/Server/${VERSION}/debian/stretch/urbackup-server_${VERSION}_amd64.deb /root/urbackup.deb
+RUN if [ "${VERSION}" = "latest" ] ; then \
+    LATEST=$(wget https://hndl.urbackup.org/Server/latest/debian/stretch/ -q -O - | tr '\n' '\r' | sed -r 's/.*server_([0-9\.]+)_amd64\.deb.*/\1/') && \
+    wget -O /root/urbackup.deb https://hndl.urbackup.org/Server/latest/debian/stretch/urbackup-server_${LATEST}_amd64.deb; \
+    else wget -O /root/urbackup.deb https://www.urbackup.org/downloads/Server/${VERSION}/debian/stretch/urbackup-server_${VERSION}_amd64.deb; \
+    fi
+
 RUN DEBIAN_FRONTEND=noninteractive dpkg -i /root/urbackup.deb  || true
 
 ADD backupfolder /etc/urbackup/backupfolder

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 [![Docker Automated buil](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/tristanteu/urbackup-docker/)
 
-`Version 2.2.11`
-
 UrBackup is an easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time.
 
 [www.urbackup.org](https://www.urbackup.org/index.html)


### PR DESCRIPTION
Please have a look if this is ok for you. 

It's possible to give the build-argument VERSION to the build command to get a specific version. If not given the build command will find the latest version and install it automatically (only during build). 
All you have to (could) do is to set up a automated build (like every week) so an up-to-date version (system and urbackup) will be available on your docker-hub.

I tested setting the version manually and using the latest-arg, works like a charm.